### PR TITLE
Add interface for getFile API call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>"]
 
 description = "A library for creating Telegram bots."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,31 @@ impl Api {
         self.send_request("sendVideo", params, RequestType::Multipart(path_file))
     }
 
+    /// Corresponds to the `getFile` method of the API.
+    pub fn get_file(&self, file_id: &str) -> Result<types::File> {
+        // Prepare parameters
+        let mut params = Params::new();
+        params.add_get("file_id", file_id);
+
+        // Execute request
+        self.send_request("getFile", params, RequestType::Post)
+    }
+
+    /// Return the URL associated with a given path.
+    /// URL is in the form of
+    /// `https://api.telegram.org/file/bot<token>/<file_path>`.
+    pub fn get_file_url(&self, file_path: &str) -> String {
+        let mut url = self.url.clone();
+        url.path_mut().map(|path| {
+            path.insert(0, "file".into());
+            path.last_mut().map(|last| {
+                *last = file_path.into()
+            })
+        });
+
+        url.serialize()
+    }
+
     /// Corresponds to the `setWebhook` method of the API.
     ///
     /// **Note:**

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -390,7 +390,8 @@ pub enum MessageType {
     Text(String),
     Audio(Audio),
     Voice(Voice),
-    File(Document),
+    Document(Document),
+    File(File),
     Photo(Vec<PhotoSize>),
     Sticker(Sticker),
     Video(Video),
@@ -426,9 +427,9 @@ impl Decodable for MessageType {
         maybe_field!(d, "text", Text);
         maybe_field!(d, "audio", Audio);
         maybe_field!(d, "voice", Voice);
-        maybe_field!(d, "file", File);
+        maybe_field!(d, "file_id", File);
         maybe_field!(d, "photo", Photo);
-        maybe_field!(d, "document", File);
+        maybe_field!(d, "document", Document);
         maybe_field!(d, "sticker", Sticker);
         maybe_field!(d, "video", Video);
         maybe_field!(d, "contact", Contact);
@@ -568,6 +569,19 @@ pub struct Document {
 impl_encode!(Document, 5,
     [0 => file_id, 1 => thumb],
     [2 => file_name, 3 => mime_type, 4 => file_size]);
+
+// ---------------------------------------------------------------------------
+/// Telegram type "File" (directly mapped)
+#[derive(RustcDecodable, Debug, PartialEq, Clone)]
+pub struct File {
+    pub file_id: String,
+    pub file_size: Option<Integer>,
+    pub file_path: Option<String>,
+}
+
+impl_encode!(File, 3,
+    [0 => file_id],
+    [1 => file_size, 2 => file_path]);
 
 // ---------------------------------------------------------------------------
 /// Telegram type "Sticker" (directly mapped)


### PR DESCRIPTION
Renamed File struct to Document add new File struct
to be more consistent with Telegram API. Bumped version
number due to breaking API chage.
