### PR TITLE
Fix property on NewChatPhoto struct (issue #92)

### DIFF
--- a/raw/src/types/message.rs
+++ b/raw/src/types/message.rs
@@ -163,7 +163,7 @@ pub enum MessageKind {
     /// New chat photo.
     NewChatPhoto {
         /// A chat photo was change to this value.
-        data: PhotoSize,
+        data: Vec<PhotoSize>,
     },
     /// Service message: the chat photo was deleted.
     DeleteChatPhoto,
@@ -531,7 +531,7 @@ pub struct RawMessage {
     /// A chat title was changed to this value.
     pub new_chat_title: Option<String>,
     /// A chat photo was change to this value.
-    pub new_chat_photo: Option<PhotoSize>,
+    pub new_chat_photo: Option<Vec<PhotoSize>>,
     /// Service message: the chat photo was deleted.
     pub delete_chat_photo: Option<True>,
     /// Service message: the group has been created.


### PR DESCRIPTION
Due to Telegram Bot API specifications:
![image](https://user-images.githubusercontent.com/15048541/38486740-33e751f8-3bde-11e8-9dd8-737c5d8da2a2.png)

The PhotoSize property should be an array and cause an error that could be not handled until the update will parsed correctly.