### PR TITLE
Switch to curl_connector by default to ease build

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.1"
 optional = true
 
 [features]
-default = ["hyper_connector"]
+default = ["curl_connector"]
 
 curl_connector = ["curl", "tokio-curl"]
 hyper_connector = ["hyper", "hyper-tls"]


### PR DESCRIPTION
Since Hyper and Hyper-tls are quite out-dated (hyper 0.11 used instead of
0.12 and hyper-tls 0.1 instead of 0.3), it is challenging to build this
crate, especially with openssl.

To solve this, swith to recent version of hyper and hyper-tls would be
great, but in the meantime, to mitigate the issue, changing the default
connector is a simple solution.