### PR TITLE
Add set_name to Sticker struct

### DIFF
--- a/raw/src/types/message.rs
+++ b/raw/src/types/message.rs
@@ -735,6 +735,8 @@ pub struct Sticker {
     pub thumb: Option<PhotoSize>,
     /// Emoji associated with the sticker.
     pub emoji: Option<String>,
+    /// The name of the sticker set this sticker belongs to.
+    pub set_name: Option<String>,
     /// File size.
     pub file_size: Option<Integer>,
 }


### PR DESCRIPTION
Add's the set_name optional string to the Sticker struct. 