### PR TITLE
Updated hyper and futures-preview, pinned hyper-tls rev

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,6 +26,6 @@ tokio-curl = {version = "0.1", optional = true}
 
 telegram-bot-raw = { version = "=0.6.3", path = "../raw" }
 
-hyper = { version = "=0.13.0-alpha.2", features=["unstable-stream"]}
-hyper-tls = { git = "https://github.com/hyperium/hyper-tls.git" }
-futures-preview = "=0.3.0-alpha.18"
+hyper = { version = "=0.13.0-alpha.4", features=["unstable-stream"]}
+hyper-tls = { git = "https://github.com/hyperium/hyper-tls.git", rev = "0ec7bf4"}
+futures-preview = "=0.3.0-alpha.19"


### PR DESCRIPTION
The current master didn't build. I've bumped the versions of the hyper and futures-preview crates and pinned the hyper-tls crate to the current git commit (They updated their hyper version which caused the current master to stop building).  
All tests ran successfully.