### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,20 @@
+name: Fmt
+
+on: [push, pull_request]
+
+jobs:
+  fmt:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        rust:
+          - stable
+          - beta
+          - nightly
+          - toolchain-file
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install toolchain
+        if: matrix.rust != 'toolchain-file'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
-      - uses: GenesisSam/get-simple-file-action@v1.0.4
+      - name: Read MSRV toolchain
+        uses: GenesisSam/get-simple-file-action@v1.0.4
         if: matrix.rust == 'toolchain-file'
         id: read-toolchain-file
         with:
@@ -36,7 +37,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
-      - name: Install msrv toolchain
+      - name: Install MSRV toolchain
         if: matrix.rust == 'toolchain-file'
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Rust
 on: [push, pull_request]
 
 jobs:
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -32,8 +33,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --all
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - macOS-latest
           - windows-latest
         rust:
-          - stable
+#          - stable
           - beta
           - nightly
           - toolchain-file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
 
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,24 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
+      - uses: GenesisSam/get-simple-file-action@v1.0.4
+        if: matrix.rust == 'toolchain-file'
+        id: read-toolchain-file
+        with:
+          file-name: 'rust-toolchain'
+
       - name: Install toolchain
         if: matrix.rust != 'toolchain-file'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install msrv toolchain
+        if: matrix.rust == 'toolchain-file'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.read-toolchain-file.outputs.data }}
           override: true
 
       - name: Run cargo check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Tests
 
 on: [push, pull_request]
 
@@ -55,19 +55,3 @@ jobs:
         with:
           command: test
           args: --all
-
-  fmt:
-    name: Fmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,24 @@ jobs:
         with:
           command: test
           args: --all
+
+  fmt:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Rust Telegram Bot Library
 =========================
 [![Build Status](https://img.shields.io/travis/telegram-rs/telegram-bot/master.svg)](https://travis-ci.org/telegram-rs/telegram-bot)
+[![Tests](https://github.com/telegram-rs/telegram-bot/workflows/Tests/badge.svg)](https://github.com/telegram-rs/telegram-bot/actions?workflow=Tests)
+[![Tests](https://github.com/telegram-rs/telegram-bot/workflows/Fmt/badge.svg)](https://github.com/telegram-rs/telegram-bot/actions?workflow=Fmt)
 [![License](https://img.shields.io/github/license/telegram-rs/telegram-bot.svg)]()
 [![Crates.io](https://img.shields.io/crates/v/telegram-bot.svg)](https://crates.io/crates/telegram-bot)
 


### PR DESCRIPTION
I think we can try actions without disabling travis builds for now.

It tests project with toolchain from `rust-toolchain` file, beta and nightly. It also checks formatting with rustfmt. 