### PR TITLE
Upgrade all dependencies to stable tokio 0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - macOS-latest
           - windows-latest
         rust:
-#          - stable
+          - stable
           - beta
           - nightly
           - toolchain-file

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,6 +31,6 @@ telegram-bot-raw = { version = "0.7.0", path = "../raw" }
 hyper = "0.13"
 hyper-tls = { version = "0.4", optional = true  }
 futures = "0.3"
-hyper-rustls = { version = "0.18", optional = true }
+hyper-rustls = { version = "0.19", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.1.5"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,10 +20,10 @@ rustls = ["hyper-rustls"]
 default = ["openssl"]
 [dependencies]
 bytes = "0.5"
-tokio = { version = "0.2", features = ["macros", "time", "fs"] }
+tokio = { version = "0.2", features = ["fs"]}
 
 tracing = "0.1.9"
-tracing-futures = { version = "0.1.0", features = ["std-future"] }
+tracing-futures = "0.2"
 multipart = { version = "0.16", default-features = false, features = ["client"] }
 
 telegram-bot-raw = { version = "0.7.0", path = "../raw" }
@@ -34,3 +34,4 @@ futures = "0.3"
 hyper-rustls = { version = "0.19", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.1.5"
+tokio = { version = "0.2", features = ["macros", "time", "fs"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,9 +26,9 @@ tracing = "0.1.9"
 tracing-futures = { version = "0.1.0", features = ["std-future"] }
 multipart = { version = "0.16", default-features = false, features = ["client"] }
 
-telegram-bot-raw = { version = "0.7.0-alpha.0", path = "../raw" }
+telegram-bot-raw = { version = "0.7.0", path = "../raw" }
 
-hyper = { version = "0.13", features = ["stream"] }
+hyper = "0.13"
 hyper-tls = { version = "0.4", optional = true  }
 futures = "0.3"
 hyper-rustls = { version = "0.18", optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.7.0-alpha.0"
+version = "0.7.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>", "Gustavo Aguiar <gustavo.h.o.aguiar@gmail.com>"]
 edition = "2018"
 
@@ -19,18 +19,18 @@ openssl = ["hyper-tls"]
 rustls = ["hyper-rustls"]
 default = ["openssl"]
 [dependencies]
-bytes = "0.4.12"
-tokio = "0.2.0-alpha.6"
+bytes = "0.5"
+tokio = { version = "0.2", features = ["macros", "time", "fs"] }
 
 tracing = "0.1.9"
 tracing-futures = { version = "0.1.0", features = ["std-future"] }
 multipart = { version = "0.16", default-features = false, features = ["client"] }
 
-telegram-bot-raw = { version = "=0.7.0-alpha.0", path = "../raw" }
+telegram-bot-raw = { version = "0.7.0-alpha.0", path = "../raw" }
 
-hyper = { version = "=0.13.0-alpha.4", features=["unstable-stream"]}
-hyper-tls = { version = "=0.4.0-alpha.4", optional = true  }
-futures-preview = "=0.3.0-alpha.19"
-hyper-rustls = { version = "=0.18.0-alpha.2", optional = true }
+hyper = { version = "0.13", features = ["stream"] }
+hyper-tls = { version = "0.4", optional = true  }
+futures = "0.3"
+hyper-rustls = { version = "0.18", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.1.5"

--- a/lib/examples/features.rs
+++ b/lib/examples/features.rs
@@ -1,10 +1,10 @@
 use std::env;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::StreamExt;
 use telegram_bot::prelude::*;
 use telegram_bot::{Api, Error, Message, MessageKind, ParseMode, UpdateKind};
-use tokio::timer::delay;
+use tokio::time::delay_for;
 
 async fn test_message(api: Api, message: Message) -> Result<(), Error> {
     api.send(message.text_reply("Simple message")).await?;
@@ -46,13 +46,11 @@ async fn test_forward(api: Api, message: Message) -> Result<(), Error> {
 async fn test_edit_message(api: Api, message: Message) -> Result<(), Error> {
     let message1 = api.send(message.text_reply("Round 1")).await?;
 
-    let when = Instant::now() + Duration::from_secs(2);
-    delay(when).await;
+    delay_for(Duration::from_secs(2)).await;
 
     let message2 = api.send(message1.edit_text("Round 2")).await?;
 
-    let when = Instant::now() + Duration::from_secs(4);
-    delay(when).await;
+    delay_for(Duration::from_secs(4)).await;
 
     api.send(message2.edit_text("Round 3")).await?;
     Ok(())

--- a/lib/examples/live_location.rs
+++ b/lib/examples/live_location.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use telegram_bot::*;
-use tokio::timer::delay_for;
+use tokio::time::delay_for;
 
 const DELAY_DURATION: Duration = Duration::from_secs(2);
 

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot-raw"
-version = "0.7.0-alpha.0"
+version = "0.7.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>", "Gustavo Aguiar <gustavo.h.o.aguiar@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 license = "MIT"
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 serde_json = "1"

--- a/raw/src/types/text.rs
+++ b/raw/src/types/text.rs
@@ -19,7 +19,7 @@ impl From<String> for Text {
 
 impl<'a> From<&'a str> for Text {
     fn from(value: &'a str) -> Self {
-        Text(value.into())
+        Text(value.to_owned().into())
     }
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-beta
+stable


### PR DESCRIPTION
Hyper 0.13 (and Hyper-tls 0.4) stable was released 8 days ago, following tokio 0.2

I upgraded all alpha dependencies to stable.

* `tokio::timer` is now `tokio::time`
* `Timeout::new` no longer exists and has been replaced by the `timeout` function
* `timer::delay` now longer exists and has been replaced by `timer::delay_for`
* `hyper::client::Client` requires `Clone`, `Send`, and `Sync` for the Connector
* `hyper_tls::HttpsConnector::new` doesn't return a `Result` anymore
* `bytes::Bytes` v0.5 no longer implements `Extend<u8>`, the fix to aggregate the body is to use `hyper::body::to_bytes`
* `bytes::Bytes` doesn't copy the `&str` anymore in `From` implementation and requires an owned string instead

I also incremented the version of telegram-bot and telegram-bot-raw to `0.7.0`, and changed the toolchain to stable because beta is no longer needed.

