### PR TITLE
Account for when a `ChannelPost` is returned from `SendMessage`

### DIFF
--- a/raw/src/requests/send_message.rs
+++ b/raw/src/requests/send_message.rs
@@ -24,7 +24,7 @@ pub struct SendMessage<'s> {
 
 impl<'c, 's> Request for SendMessage<'s> {
     type Type = JsonRequestType<Self>;
-    type Response = JsonIdResponse<Message>;
+    type Response = JsonIdResponse<MessageOrChannelPost>;
 
     fn serialize(&self) -> Result<HttpRequest, Error> {
         Self::Type::serialize(RequestUrl::method("sendMessage"), self)


### PR DESCRIPTION
This PR fixes an error that occurs after sending a reply to a `ChannelPost`.

Replying to a `ChannelPost` results in the following error:
```
Error: Error(Raw(Error(Json(Error("Missing `from` field for Message", line: 1, column: 356)))))
```

### Repro

```rust
async fn handle_message<M>(api: &Api, message: M) -> Result<(), Error>
where
    M: MessageText + WithTimestamp + CanReplySendMessage,
{
    match message.text() {
        Some(ref text) => match text.as_str() {
            "/my_command" => {
                // This line returns the following error after replying to a `ChannelPost`:
                // "Missing `from` field for Message".
                let response = api.send(message.text_reply(command_response)).await?;
                Ok(())
            }
            _ => Ok(()),
        },
        None => Ok(()),
    }
}

#[tokio::main]
async fn main() -> Result<(), Error> {
    dotenv().ok();

    let token = env::var("TELEGRAM_BOT_TOKEN").expect("TELEGRAM_BOT_TOKEN not set");
    let api = Api::new(token);

    let mut stream = api.stream();
    while let Some(update) = stream.next().await {
        match update?.kind {
            UpdateKind::Message(message) => handle_message(&api, message).await?,
            UpdateKind::ChannelPost(channel_post) => handle_message(&api, channel_post).await?,
            _ => (),
        }
    }

    Ok(())
}
```