### PR TITLE
Make UpdatesStream Send

### DIFF
--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -24,7 +24,8 @@ pub struct UpdatesStream {
     api: Api,
     last_update: Integer,
     buffer: VecDeque<Update>,
-    current_request: Option<Pin<Box<dyn Future<Output = Result<Option<Vec<Update>>, Error>>>>>,
+    current_request:
+        Option<Pin<Box<dyn Future<Output = Result<Option<Vec<Update>>, Error>> + Send>>>,
     timeout: Duration,
     allowed_updates: Vec<AllowedUpdate>,
     limit: Integer,


### PR DESCRIPTION
As per https://github.com/telegram-rs/telegram-bot/issues/192, `UpdatesStream` does not implement `Send` because the trait object is not inferred to implement `Send`. This PR fixes it, allowing streams to be used with `tokio::spawn` and such.