### PR TITLE
Update README.md to specify that tokio 0.2 is required for the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 ```
+To use the above example you must add tokio 0.2 to your cargo.toml (tokio 0.3 will not work with the above example):
+`tokio = { version = "0.2", features = ["macros", "time", "fs"] }`
+
 You can find a bigger examples in the `examples`.
 
 ## Usage


### PR DESCRIPTION
... this took me a while to figure out and might cause future users issues. With tokio 0.3, the listed example will not run. 