### PR TITLE
Do not fail on unknown sender name

### DIFF
--- a/raw/src/types/message.rs
+++ b/raw/src/types/message.rs
@@ -257,6 +257,12 @@ impl Message {
                     sender_name: sender_name.clone(),
                 },
             }),
+            (Some(date), _, _, _, _) => Some(Forward {
+                date,
+                from: ForwardFrom::ChannelHiddenUser {
+                    sender_name: "unknown".to_string(),
+                },
+            }),
             _ => return Err(format!("invalid forward fields combination")),
         };
 
@@ -395,6 +401,12 @@ impl ChannelPost {
                 date,
                 from: ForwardFrom::ChannelHiddenUser {
                     sender_name: sender_name.clone(),
+                },
+            }),
+            (Some(date), _, _, _, _) => Some(Forward {
+                date,
+                from: ForwardFrom::ChannelHiddenUser {
+                    sender_name: "unknown".to_string(),
                 },
             }),
             _ => return Err(format!("invalid forward fields combination")),


### PR DESCRIPTION
Fixes https://github.com/telegram-rs/telegram-bot/issues/223

Failures are related to missing sender name. It may be caused by recent changes in Telegram API. I didn't dive deep enough. 

The changes in this PR fix failures in my bot and it works for me. But it may hide a bigger issue.