### PR TITLE
Bump deps

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,7 +22,7 @@ default = ["openssl"]
 bytes = "1.0.1"
 tokio = { version = "1.2", features = ["fs", "rt"]}
 
-tracing = "0.1.9"
+tracing = "0.1.23"
 tracing-futures = "0.2"
 multipart = { version = "0.17", default-features = false, features = ["client"] }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,8 +19,8 @@ openssl = ["hyper-tls"]
 rustls = ["hyper-rustls"]
 default = ["openssl"]
 [dependencies]
-bytes = "0.5"
-tokio = { version = "0.2", features = ["fs"]}
+bytes = "1.0.1"
+tokio = { version = "1.2", features = ["fs", "rt"]}
 
 tracing = "0.1.9"
 tracing-futures = "0.2"
@@ -34,4 +34,4 @@ futures = "0.3"
 hyper-rustls = { version = "0.19", optional = true }
 [dev-dependencies]
 tracing-subscriber = "0.1.5"
-tokio = { version = "0.2", features = ["macros", "time", "fs"] }
+tokio = { version = "1.2", features = ["macros", "time", "fs", "rt-multi-thread"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,14 +24,14 @@ tokio = { version = "1.2", features = ["fs", "rt"]}
 
 tracing = "0.1.9"
 tracing-futures = "0.2"
-multipart = { version = "0.16", default-features = false, features = ["client"] }
+multipart = { version = "0.17", default-features = false, features = ["client"] }
 
 telegram-bot-raw = { version = "0.8.0", path = "../raw" }
 
 hyper = "0.13"
 hyper-tls = { version = "0.4", optional = true  }
 futures = "0.3"
-hyper-rustls = { version = "0.19", optional = true }
+hyper-rustls = { version = "0.22", optional = true }
 [dev-dependencies]
-tracing-subscriber = "0.1.5"
+tracing-subscriber = "0.2.15"
 tokio = { version = "1.2", features = ["macros", "time", "fs", "rt-multi-thread"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>", "Gustavo Aguiar <gustavo.h.o.aguiar@gmail.com>"]
 edition = "2018"
 
@@ -26,7 +26,7 @@ tracing = "0.1.23"
 tracing-futures = "0.2"
 multipart = { version = "0.17", default-features = false, features = ["client"] }
 
-telegram-bot-raw = { version = "0.8.0", path = "../raw" }
+telegram-bot-raw = { version = "0.9.0", path = "../raw" }
 
 hyper = { version = "0.14", features = ["client", "http1"] }
 hyper-tls = { version = "0.5", optional = true  }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,8 +28,8 @@ multipart = { version = "0.17", default-features = false, features = ["client"] 
 
 telegram-bot-raw = { version = "0.8.0", path = "../raw" }
 
-hyper = "0.13"
-hyper-tls = { version = "0.4", optional = true  }
+hyper = { version = "0.14", features = ["client", "http1"] }
+hyper-tls = { version = "0.5", optional = true  }
 futures = "0.3"
 hyper-rustls = { version = "0.22", optional = true }
 [dev-dependencies]

--- a/lib/examples/features.rs
+++ b/lib/examples/features.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use telegram_bot::prelude::*;
 use telegram_bot::{Api, Error, Message, MessageKind, ParseMode, UpdateKind};
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 async fn test_message(api: Api, message: Message) -> Result<(), Error> {
     api.send(message.text_reply("Simple message")).await?;
@@ -46,11 +46,11 @@ async fn test_forward(api: Api, message: Message) -> Result<(), Error> {
 async fn test_edit_message(api: Api, message: Message) -> Result<(), Error> {
     let message1 = api.send(message.text_reply("Round 1")).await?;
 
-    delay_for(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2)).await;
 
     let message2 = api.send(message1.edit_text("Round 2")).await?;
 
-    delay_for(Duration::from_secs(4)).await;
+    sleep(Duration::from_secs(4)).await;
 
     api.send(message2.edit_text("Round 3")).await?;
     Ok(())

--- a/lib/examples/live_location.rs
+++ b/lib/examples/live_location.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use telegram_bot::*;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 const DELAY_DURATION: Duration = Duration::from_secs(2);
 
@@ -12,13 +12,13 @@ async fn test(api: Api, message: Message) -> Result<(), Error> {
         .send(message.location_reply(0.0, 0.0).live_period(60))
         .await?;
 
-    delay_for(DELAY_DURATION).await;
+    sleep(DELAY_DURATION).await;
     api.send(reply.edit_live_location(10.0, 10.0)).await?;
 
-    delay_for(DELAY_DURATION).await;
+    sleep(DELAY_DURATION).await;
     api.send(reply.edit_live_location(20.0, 20.0)).await?;
 
-    delay_for(DELAY_DURATION).await;
+    sleep(DELAY_DURATION).await;
     api.send(reply.edit_live_location(30.0, 30.0)).await?;
 
     Ok(())

--- a/lib/examples/poll.rs
+++ b/lib/examples/poll.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::time::Duration;
 
 use futures::StreamExt;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use telegram_bot::prelude::*;
 use telegram_bot::{
@@ -19,7 +19,7 @@ fn make_test_poll<'p>(message: Message) -> SendPoll<'p, 'p, 'p> {
 async fn send_and_stop_poll<'p>(api: Api, poll: SendPoll<'p, 'p, 'p>) -> Result<(), Error> {
     let poll_message = api.send(poll).await?;
 
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
 
     api.send(poll_message.stop_poll()).await?;
     Ok(())

--- a/lib/src/connector/hyper.rs
+++ b/lib/src/connector/hyper.rs
@@ -159,7 +159,7 @@ impl<C: Connect + std::fmt::Debug + 'static + Clone + Send + Sync> Connector for
 
 pub fn default_connector() -> Result<Box<dyn Connector>, Error> {
     #[cfg(feature = "rustls")]
-    let connector = HttpsConnector::new();
+    let connector = HttpsConnector::with_native_roots();
 
     #[cfg(feature = "openssl")]
     let connector = HttpsConnector::new();

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 license = "MIT"
 
 [dependencies]
-bytes = "0.5"
+bytes = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 serde_json = "1"

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot-raw"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>", "Gustavo Aguiar <gustavo.h.o.aguiar@gmail.com>"]
 edition = "2018"
 

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -19,4 +19,4 @@ bytes = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 serde_json = "1"
-serde-value = "0.5.2"
+serde-value = "0.7.0"


### PR DESCRIPTION
Bumping telegram-bot deps:
- bump bytes and tokio to 1.0 version (Closes #220)
- bump multipart to 0.17 version
- bump serde-value to 0.7.0 version
- bump hyper to 0.14 version and hyper-tls to next version

Also this PR enabled reproducible builds via Cargo.lock. This file was used to
track changes in dependencies. If it is unnecessary - tell me and I will
remove restoring Cargo.lock from this patchset.


Blocked on:
- [x] https://github.com/hyperium/hyper-tls/pull/79 or https://github.com/hyperium/hyper-tls/pull/83 was merged
- [x] hyper-tls was released next version.
