### PR TITLE
Implement ChosenInlineResult

### DIFF
--- a/raw/src/requests/get_updates.rs
+++ b/raw/src/requests/get_updates.rs
@@ -66,7 +66,7 @@ pub enum AllowedUpdate {
     EditedChannelPost,
     #[serde(rename = "inline_query")]
     InlineQuery,
-    #[serde(rename = "chosen_inline_query")]
+    #[serde(rename = "chosen_inline_result")]
     ChosenInlineResult,
     #[serde(rename = "callback_query")]
     CallbackQuery,

--- a/raw/src/types/chosen_inline_result.rs
+++ b/raw/src/types/chosen_inline_result.rs
@@ -1,0 +1,11 @@
+use crate::types::*;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize)]
+pub struct ChosenInlineResult {
+    pub result_id: String,
+    pub from: User,
+    pub location: Option<Location>,
+    pub inline_message_id: Option<String>,
+    pub query: String,
+}

--- a/raw/src/types/mod.rs
+++ b/raw/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod callback_query;
 pub mod chat;
 pub mod chat_member;
+pub mod chosen_inline_result;
 pub mod inline_query;
 pub mod inline_query_result;
 pub mod input_file;
@@ -15,6 +16,7 @@ pub mod update;
 pub use self::callback_query::*;
 pub use self::chat::*;
 pub use self::chat_member::*;
+pub use self::chosen_inline_result::*;
 pub use self::inline_query::*;
 pub use self::inline_query_result::*;
 pub use self::input_file::*;

--- a/raw/src/types/update.rs
+++ b/raw/src/types/update.rs
@@ -29,7 +29,8 @@ pub enum UpdateKind {
     EditedChannelPost(ChannelPost),
     #[serde(rename = "inline_query")]
     InlineQuery(InlineQuery),
-    //    ChosenInlineResult(ChosenInlineResult),
+    #[serde(rename = "chosen_inline_result")]
+    ChosenInlineResult(ChosenInlineResult),
     #[serde(rename = "callback_query")]
     CallbackQuery(CallbackQuery),
     /// New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot


### PR DESCRIPTION
This PR adds support for the chosen_inline_result update (https://core.telegram.org/bots/api#getting-updates).