### PR TITLE
Add HTTP/2 support for hyper

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ multipart = { version = "0.17", default-features = false, features = ["client"] 
 
 telegram-bot-raw = { version = "0.9.0", path = "../raw" }
 
-hyper = { version = "0.14", features = ["client", "http1"] }
+hyper = { version = "0.14", features = ["client", "http1", "http2"] }
 hyper-tls = { version = "0.5", optional = true  }
 futures = "0.3"
 hyper-rustls = { version = "0.22", optional = true }


### PR DESCRIPTION
`api.telegram.org` responds with HTTP/2. Without `http2` feature `hyper` can't connect with error "invalid HTTP version parsed".