### PR TITLE
Make `ErrorKind` public

### DIFF
--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -2,10 +2,10 @@ use std::error;
 use std::fmt;
 
 #[derive(Debug)]
-pub struct Error(ErrorKind);
+pub struct Error(pub ErrorKind);
 
 #[derive(Debug)]
-pub(crate) enum ErrorKind {
+pub enum ErrorKind {
     Raw(telegram_bot_raw::Error),
     Hyper(hyper::Error),
     Http(hyper::http::Error),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -12,7 +12,7 @@ pub mod types;
 pub mod util;
 
 pub use self::api::Api;
-pub use self::errors::Error;
+pub use self::errors::{Error, ErrorKind};
 pub use prelude::*;
 pub use stream::UpdatesStream;
 pub use types::*;

--- a/raw/src/requests/_base/errors.rs
+++ b/raw/src/requests/_base/errors.rs
@@ -4,10 +4,10 @@ use std::fmt;
 use crate::types::*;
 
 #[derive(Debug)]
-pub struct Error(ErrorKind);
+pub struct Error(pub ErrorKind);
 
 #[derive(Debug)]
-pub(crate) enum ErrorKind {
+pub enum ErrorKind {
     EmptyBody,
     TelegramError {
         description: String,

--- a/raw/src/requests/_base/mod.rs
+++ b/raw/src/requests/_base/mod.rs
@@ -2,8 +2,7 @@ mod _base;
 pub use self::_base::*;
 
 mod errors;
-pub use self::errors::Error;
-pub(crate) use self::errors::ErrorKind;
+pub use self::errors::{Error, ErrorKind};
 
 mod http;
 pub use self::http::{Body, Multipart, MultipartValue, RequestUrl};


### PR DESCRIPTION
Is it really necessary to hide `ErrorKind`? If it's not, I've made the PR.