### PR TITLE
Support sidevm runtime

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,10 +17,14 @@ license = "MIT"
 [features]
 openssl = ["hyper-tls"]
 rustls = ["hyper-rustls"]
-default = ["openssl"]
+tokio-runtime = ["tokio"]
+sidevm-runtime = ["sidevm"]
+default = ["openssl", "tokio-runtime"]
+
 [dependencies]
 bytes = "1.0.1"
-tokio = { version = "1.2", features = ["fs", "rt"]}
+tokio = { version = "1.2", features = ["fs", "rt"], optional = true }
+sidevm = { version = "0.1", optional = true }
 
 tracing = "0.1.23"
 tracing-futures = "0.2"
@@ -32,6 +36,7 @@ hyper = { version = "0.14", features = ["client", "http1"] }
 hyper-tls = { version = "0.5", optional = true  }
 futures = "0.3"
 hyper-rustls = { version = "0.22", optional = true }
+
 [dev-dependencies]
 tracing-subscriber = "0.2.15"
 tokio = { version = "1.2", features = ["macros", "time", "fs", "rt-multi-thread"] }

--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -5,7 +5,10 @@ use std::sync::{
 use std::time::Duration;
 
 use futures::{Future, FutureExt};
-use tokio::time::timeout;
+#[cfg(feature = "sidevm-runtime")]
+use sidevm::{spawn, time::timeout};
+#[cfg(feature = "tokio-runtime")]
+use tokio::{spawn, time::timeout};
 use tracing_futures::Instrument;
 
 use telegram_bot_raw::{HttpRequest, Request, ResponseType};
@@ -94,7 +97,7 @@ impl Api {
     pub fn spawn<Req: Request>(&self, request: Req) {
         let api = self.clone();
         if let Ok(request) = request.serialize() {
-            tokio::spawn(async move {
+            spawn(async move {
                 let _ = api.send_http_request::<Req::Response>(request).await;
             });
         }


### PR DESCRIPTION
This PR adds support running telegram-bot under Phala network's sidevm environment.

The sidevm is a smart contract platform where `tokio runtime` is not available and it provides a `sidevm runtime` instead.