### PR TITLE
Location accuracy and other props

### DIFF
--- a/raw/src/types/message.rs
+++ b/raw/src/types/message.rs
@@ -875,6 +875,12 @@ pub struct Location {
     pub longitude: Float,
     /// Latitude as defined by sender.
     pub latitude: Float,
+    /// The radius of uncertainty for the location, measured in meters. 0~1500m
+    pub horizontal_accuracy: Option<Float>,
+    /// Time(in seconds) relative to the message sending date, during which the location can be updated. For active live locations only.
+    pub live_period: Option<Integer>,
+    /// The direction in which user is moving, in degrees(1~360°). For active live locations only.
+    pub heading: Option<Integer>,
 }
 
 /// This object represents a venue.


### PR DESCRIPTION
Location struct changed to provide `horizontal_accuracy`, `live_period` and `heading` information. They are optional, but very useful for live locations.

More about [telegram location](https://core.telegram.org/bots/api#location).