### PR TITLE
Make hyper and tokio optional dependencies

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,10 +17,11 @@ license = "MIT"
 [features]
 openssl = ["hyper-tls"]
 rustls = ["hyper-rustls"]
-default = ["openssl"]
+runtime-tokio = ["tokio"]
+connector-hyper = ["hyper", "runtime-tokio"]
+default = ["openssl", "connector-hyper"]
 [dependencies]
 bytes = "1.0.1"
-tokio = { version = "1.2", features = ["fs", "rt"]}
 
 tracing = "0.1.23"
 tracing-futures = "0.2"
@@ -28,7 +29,8 @@ multipart = { version = "0.17", default-features = false, features = ["client"] 
 
 telegram-bot-raw = { version = "0.9.0", path = "../raw" }
 
-hyper = { version = "0.14", features = ["client", "http1"] }
+tokio = { version = "1.2", features = ["fs", "rt"], optional = true }
+hyper = { version = "0.14", features = ["client", "http1"], optional = true }
 hyper-tls = { version = "0.5", optional = true  }
 futures = "0.3"
 hyper-rustls = { version = "0.22", optional = true }

--- a/lib/src/connector/mod.rs
+++ b/lib/src/connector/mod.rs
@@ -1,5 +1,6 @@
 //! Connector with hyper backend.
 
+#[cfg(feature = "connector-hyper")]
 pub mod hyper;
 
 use std::fmt::Debug;
@@ -18,6 +19,7 @@ pub trait Connector: Debug + Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Error>> + Send>>;
 }
 
+#[cfg(feature = "hyper")]
 pub fn default_connector() -> Box<dyn Connector> {
     hyper::default_connector().unwrap()
 }

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -5,12 +5,25 @@ use std::fmt;
 pub struct Error(ErrorKind);
 
 #[derive(Debug)]
-pub(crate) enum ErrorKind {
+pub enum ErrorKind {
     Raw(telegram_bot_raw::Error),
+    #[cfg(feature = "connector-hyper")]
     Hyper(hyper::Error),
+    #[cfg(feature = "connector-hyper")]
     Http(hyper::http::Error),
     Io(std::io::Error),
     InvalidMultipartFilename,
+    Generic(Box<dyn std::error::Error + Send>),
+}
+
+impl ErrorKind {
+    pub fn from_generic<E: std::error::Error + Send + 'static>(e: E) -> Self {
+        Self::Generic(Box::new(e))
+    }
+
+    pub fn from_generic_boxed(e: Box<dyn std::error::Error + Send>) -> Self {
+        Self::Generic(e)
+    }
 }
 
 impl From<telegram_bot_raw::Error> for ErrorKind {
@@ -19,12 +32,14 @@ impl From<telegram_bot_raw::Error> for ErrorKind {
     }
 }
 
+#[cfg(feature = "connector-hyper")]
 impl From<hyper::Error> for ErrorKind {
     fn from(error: hyper::Error) -> Self {
         ErrorKind::Hyper(error)
     }
 }
 
+#[cfg(feature = "connector-hyper")]
 impl From<hyper::http::Error> for ErrorKind {
     fn from(error: hyper::http::Error) -> Self {
         ErrorKind::Http(error)
@@ -47,10 +62,13 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             ErrorKind::Raw(error) => write!(f, "{}", error),
+            #[cfg(feature = "connector-hyper")]
             ErrorKind::Hyper(error) => write!(f, "{}", error),
+            #[cfg(feature = "connector-hyper")]
             ErrorKind::Http(error) => write!(f, "{}", error),
             ErrorKind::Io(error) => write!(f, "{}", error),
             ErrorKind::InvalidMultipartFilename => write!(f, "invalid multipart filename"),
+            ErrorKind::Generic(error) => write!(f, "{}", error),
         }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod util;
 
 pub use self::api::Api;
 pub use self::errors::Error;
+pub use self::errors::ErrorKind;
 pub use prelude::*;
 pub use stream::UpdatesStream;
 pub use types::*;


### PR DESCRIPTION
This pull request adds two default features `runtime-tokio` and `connector-hyper`, which control if the default runtime / connector implementation is present.

This change makes it possible to use this crate in environments where Tokio and/or hyper cannot be used, and the end user wants to provide their own Connector implementation (e.g. Cloudflare Worker (worker-rs, Fetch), Phala Network (sidevm, see #266)).

Notably, `Api::send_timeout` currently depends on Tokio, so we have to disable that if `runtime-tokio` is not selected. In those cases, we are forced to use `Api::send` without timeouts in `UpdatesStream`. This may be suboptimal, but should yield correct behavior nevertheless.